### PR TITLE
Add a command which supports password generation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ git2 = { version = "0.6", default-features = false, features = [] }
 isatty = "0.1"
 lazy_static = "0.2"
 log = "0.3"
+rand = "0.3"
 rpassword = "0.3"
 serde = "0.9"
 serde_derive = "0.9"

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -2,3 +2,4 @@ pub mod configuration;
 pub mod key;
 pub mod keystore;
 pub mod padding;
+pub mod rng;

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -2,4 +2,5 @@ pub mod configuration;
 pub mod key;
 pub mod keystore;
 pub mod padding;
+pub mod pwgen;
 pub mod rng;

--- a/src/crypto/pwgen.rs
+++ b/src/crypto/pwgen.rs
@@ -1,0 +1,49 @@
+use crypto::rng::Generator;
+use error::*;
+use rand::Rng;
+use std::collections::{HashMap, HashSet};
+use util::data::SensitiveData;
+
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub enum CharacterSet {
+    Letters,
+    Numbers,
+    Symbols,
+}
+
+lazy_static! {
+    static ref CHARACTER_SET: HashMap<CharacterSet, Vec<char>> = {
+        let mut m = HashMap::new();
+        m.insert(CharacterSet::Letters,
+                 "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ".chars().collect());
+        m.insert(CharacterSet::Numbers, "0123456789".chars().collect());
+        m.insert(CharacterSet::Symbols, "!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~".chars().collect());
+        m
+    };
+}
+
+pub const RECOMMENDED_MINIMUM_PASSWORD_LENGTH: usize = 16;
+
+pub fn generate_password(length: usize,
+                         charsets: &[CharacterSet],
+                         exclude: &[char])
+                         -> Result<SensitiveData> {
+    if length == 0 {
+        bail!("Refusing to generate a password of length 0");
+    }
+
+    let exclude: HashSet<char> = exclude.iter().cloned().collect();
+    let chars: Vec<char> = charsets.iter()
+        .flat_map(|cs| CHARACTER_SET.get(cs).unwrap().iter())
+        .filter(|c| !exclude.contains(c))
+        .cloned()
+        .collect();
+    if chars.is_empty() {
+        bail!("Cannot generate passwords from an empty character set");
+    }
+
+    let mut generator = Generator;
+    let password: String =
+        (0..length).map(|_| chars[generator.gen_range(0, chars.len())]).collect();
+    Ok(SensitiveData::from(password.into_bytes()))
+}

--- a/src/crypto/rng.rs
+++ b/src/crypto/rng.rs
@@ -1,0 +1,18 @@
+use byteorder::{LittleEndian, ReadBytesExt};
+use rand::Rng;
+use sodiumoxide::randombytes::randombytes;
+use std::io::Cursor;
+
+/// This structure implements the `Rng` trait from the `rand` crate using
+/// `sodiumoxide`'s `randombytes` function. This implies that this random
+/// number generator is both thread safe, and cryptographically secure (e.g.
+/// suitable for generating key material or passwords).
+pub struct Generator;
+
+impl Rng for Generator {
+    fn next_u32(&mut self) -> u32 {
+        let bytes = randombytes(4);
+        let mut rdr = Cursor::new(bytes);
+        rdr.read_u32::<LittleEndian>().unwrap()
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,6 +6,7 @@ error_chain! {
         Io(::std::io::Error);
         Json(::serde_json::Error);
         Log(::log::SetLoggerError);
+        ParseInt(::std::num::ParseIntError);
         Utf8(::std::string::FromUtf8Error);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ extern crate isatty;
 extern crate lazy_static;
 #[macro_use]
 extern crate log;
+extern crate rand;
 extern crate rpassword;
 extern crate serde;
 #[macro_use]

--- a/src/tests/crypto/mod.rs
+++ b/src/tests/crypto/mod.rs
@@ -4,3 +4,5 @@ mod key;
 mod keystore;
 #[cfg(test)]
 mod padding;
+#[cfg(test)]
+mod rng;

--- a/src/tests/crypto/mod.rs
+++ b/src/tests/crypto/mod.rs
@@ -5,4 +5,6 @@ mod keystore;
 #[cfg(test)]
 mod padding;
 #[cfg(test)]
+mod pwgen;
+#[cfg(test)]
 mod rng;

--- a/src/tests/crypto/pwgen.rs
+++ b/src/tests/crypto/pwgen.rs
@@ -1,0 +1,55 @@
+use crypto::pwgen::*;
+
+
+fn generate_password_str(length: Option<usize>,
+                         charsets: &[CharacterSet],
+                         exclude: &[char])
+                         -> String {
+    generate_password(length.unwrap_or(RECOMMENDED_MINIMUM_PASSWORD_LENGTH),
+                      charsets,
+                      exclude)
+        .unwrap()
+        .display(false, false)
+        .unwrap()
+}
+
+#[test]
+fn test_generating_empty_password() {
+    assert!(generate_password(0, &[CharacterSet::Letters], &[]).is_err());
+}
+
+#[test]
+fn test_generating_with_no_character_set() {
+    assert!(generate_password(RECOMMENDED_MINIMUM_PASSWORD_LENGTH, &[], &[]).is_err());
+}
+
+#[test]
+fn test_excluding_characters() {
+    let password = generate_password_str(Some(1000), &[CharacterSet::Numbers], &['7']);
+    assert!(!password.contains('7'));
+}
+
+#[test]
+fn test_excluding_all_characters() {
+    assert!(generate_password(RECOMMENDED_MINIMUM_PASSWORD_LENGTH,
+                              &[CharacterSet::Numbers],
+                              &['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'])
+        .is_err());
+}
+
+#[test]
+fn test_pwgen_charset() {
+    for _ in 0..10 {
+        let password = generate_password_str(None, &[CharacterSet::Letters], &[]);
+        assert_eq!(RECOMMENDED_MINIMUM_PASSWORD_LENGTH, password.len());
+        assert!(password.chars()
+            .map(|c| c.is_alphabetic())
+            .fold(true, |acc, isalpha| acc && isalpha));
+    }
+
+    for _ in 0..10 {
+        let password = generate_password_str(None, &[CharacterSet::Numbers], &[]);
+        assert_eq!(RECOMMENDED_MINIMUM_PASSWORD_LENGTH, password.len());
+        assert!(password.chars().map(|c| c.is_digit(10)).fold(true, |acc, isdigit| acc && isdigit));
+    }
+}

--- a/src/tests/crypto/rng.rs
+++ b/src/tests/crypto/rng.rs
@@ -1,0 +1,26 @@
+use crypto::rng::Generator;
+use rand::Rng;
+use std::collections::HashSet;
+
+#[test]
+fn test_rng_output() {
+    // Test that we get at least a few distinct values from the RNG if we generate
+    // many values. This is kind of a silly test, but it should at least protect
+    // against mis-implementing Generator so that it returns the same value every
+    // time.
+    let mut generator = Generator;
+    let values: HashSet<u64> = (0..1000).map(|_| generator.next_u64()).collect();
+    assert!(values.len() > 1);
+}
+
+#[test]
+fn test_rng_range() {
+    let mut generator = Generator;
+    let min: u64 = 123;
+    let max: u64 = 9876;
+    for _ in 0..100 {
+        let n: u64 = generator.gen_range(min, max);
+        assert!(min <= n);
+        assert!(n < max);
+    }
+}


### PR DESCRIPTION
This fixes #25. Note that there is room for better integration (e.g., generating and setting the password all in one command), but this command is functional as-is and the workaround (copy/pasting the generated password to set's stdin) is easy enough for 1.0.0.